### PR TITLE
Fix unintended change of Array which is passed as argument

### DIFF
--- a/lib/index.coffee
+++ b/lib/index.coffee
@@ -17,8 +17,8 @@ module.exports = (strings) ->
 
   strings.sort (a, b) ->
     a.length > b.length
-
-  firstString = strings.shift()
+  copy = strings.slice 0
+  firstString = copy.shift()
   result = false
 
   substrings = new SubstringIterator firstString

--- a/test/mlcs.coffee
+++ b/test/mlcs.coffee
@@ -38,3 +38,12 @@ describe "mlcs()", ->
 
     for strings in tests
       expect(mlcs(strings)).to.be.false
+  it "should not change Array which is passed as a argument", ->
+    strings = [
+        "123"
+        "456"
+        "789"
+    ]
+    copy = strings.slice 0
+    mlcs strings
+    expect(strings).to.deep.equal copy


### PR DESCRIPTION
## Problem

`mlcs(arr)` deletes 1st member of `arr`
## Example

``` coffee
arr = ["123", "12345", "123456"]
mlcs = require "mlcs"
console.log arr # =>  ["123", "12345", "123456"]
mlcs arr           # => '123'
console.log arr # => ["12345", "123456"]  "123" is deleted !!
```

This PR is for fixing this problem :smiley: 
